### PR TITLE
cleanup access to blockchain.client properties

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -105,7 +105,7 @@ class NucypherTokenActor:
     @property
     def eth_balance(self) -> Decimal:
         """Return this actors's current ETH balance"""
-        balance = self.blockchain.get_balance(self.checksum_address)
+        balance = self.blockchain.client.get_balance(self.checksum_address)
         return self.blockchain.fromWei(balance, 'ether')
 
     @property
@@ -201,7 +201,7 @@ class Deployer(NucypherTokenActor):
         if Deployer._upgradeable:
             if not plaintext_secret:
                 raise ValueError("Upgrade plaintext_secret must be passed to deploy an upgradeable contract.")
-            secret_hash = self.blockchain.keccak(bytes(plaintext_secret, encoding='utf-8'))
+            secret_hash = self.blockchain.client.keccak(bytes(plaintext_secret, encoding='utf-8'))
             txhashes = deployer.deploy(secret_hash=secret_hash, gas_limit=gas_limit)
         else:
             txhashes = deployer.deploy(gas_limit=gas_limit)

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -378,7 +378,7 @@ class UserEscrowAgent(EthereumContractAgent):
         _forward_address = False
 
         def _generate_beneficiary_agency(self, principal_address: str):
-            contract = self.blockchain.w3.eth.contract(address=principal_address, abi=self.contract.abi)
+            contract = self.blockchain.client.get_contract(address=principal_address, abi=self.contract.abi)
             return contract
 
     def __init__(self,
@@ -411,7 +411,7 @@ class UserEscrowAgent(EthereumContractAgent):
         else:
             contract_data = self.__allocation_registry.search(beneficiary_address=self.beneficiary)
         address, abi = contract_data
-        principal_contract = self.blockchain.w3.eth.contract(abi=abi, address=address, ContractFactoryClass=Contract)
+        principal_contract = self.blockchain.client.get_contract(abi=abi, address=address, ContractFactoryClass=Contract)
         self.__principal_contract = principal_contract
 
     def __set_owner(self) -> None:

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -160,14 +160,14 @@ class Web3Client(object):
 
     @property
     def etherbase(self):
-        return self.w3.eth.accounts[0]
+        return self.accounts[0]
 
     @property
     def accounts(self):
         return self.w3.eth.accounts
 
-    def get_balance(self, address):
-        return self.w3.eth.getBalance(address)
+    def get_balance(self, account):
+        return self.w3.eth.getBalance(account)
 
     def inject_middleware(self, middleware, **kwargs):
         self.w3.middleware_onion.inject(middleware, **kwargs)
@@ -175,6 +175,20 @@ class Web3Client(object):
     @property
     def chain_id(self):
         return self.w3.net.version
+
+    def get_contract(self, **kwargs):
+        return self.w3.eth.contract(**kwargs)
+
+    @property
+    def gasPrice(self):
+        return self.w3.eth.gasPrice
+
+    @property
+    def coinbase(self):
+        return self.w3.eth.coinbase
+
+    def sendTransaction(self, transaction: dict):
+        return self.w3.eth.sendTransaction(transaction)
 
     def sync(self,
              timeout: int = 120,

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -169,6 +169,9 @@ class Web3Client(object):
     def get_balance(self, address):
         return self.w3.eth.getBalance(address)
 
+    def inject_middleware(self, middleware, **kwargs):
+        self.w3.middleware_onion.inject(middleware, **kwargs)
+
     @property
     def chain_id(self):
         return self.w3.net.version

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -205,7 +205,7 @@ class DispatcherDeployer(ContractDeployer):
         if new_target == self._contract.address:
             raise self.ContractDeploymentError(f"{self.contract_name} {self._contract.address} cannot target itself.")
 
-        origin_args = {'from': self.deployer_address, 'gasPrice': self.blockchain.w3.eth.gasPrice}  # TODO: Gas management
+        origin_args = {'from': self.deployer_address, 'gasPrice': self.blockchain.client.gasPrice}  # TODO: Gas management
         upgrade_function = self._contract.functions.upgrade(new_target, existing_secret_plaintext, new_secret_hash)
         upgrade_receipt = self.blockchain.send_transaction(transaction_function=upgrade_function,
                                                            sender_address=self.deployer_address,
@@ -213,7 +213,7 @@ class DispatcherDeployer(ContractDeployer):
         return upgrade_receipt
 
     def rollback(self, existing_secret_plaintext: bytes, new_secret_hash: bytes) -> dict:
-        origin_args = {'from': self.deployer_address, 'gasPrice': self.blockchain.w3.eth.gasPrice}  # TODO: Gas management
+        origin_args = {'from': self.deployer_address, 'gasPrice': self.blockchain.client.gasPrice}  # TODO: Gas management
         rollback_function = self._contract.functions.rollback(existing_secret_plaintext, new_secret_hash)
         rollback_receipt = self.blockchain.send_transaction(transaction_function=rollback_function,
                                                             sender_address=self.deployer_address,
@@ -265,7 +265,7 @@ class StakingEscrowDeployer(ContractDeployer):
 
         # Build deployment arguments
         origin_args = {'from': self.deployer_address,
-                       'gasPrice': self.blockchain.w3.eth.gasPrice}
+                       'gasPrice': self.blockchain.client.gasPrice}
         if gas_limit:
             origin_args.update({'gas': gas_limit})
 
@@ -642,7 +642,7 @@ class UserEscrowDeployer(ContractDeployer):
         """Relinquish ownership of a UserEscrow deployment to the beneficiary"""
         if not is_checksum_address(beneficiary_address):
             raise self.ContractDeploymentError("{} is not a valid checksum address.".format(beneficiary_address))
-        payload = {'from': self.deployer_address, 'gas': 500_000, 'gasPrice': self.blockchain.w3.eth.gasPrice}
+        payload = {'from': self.deployer_address, 'gas': 500_000, 'gasPrice': self.blockchain.client.gasPrice}
         transfer_owner_function = self.contract.functions.transferOwnership(beneficiary_address)
         transfer_owner_receipt = self.blockchain.send_transaction(transaction_function=transfer_owner_function,
                                                                   payload=payload,
@@ -662,7 +662,7 @@ class UserEscrowDeployer(ContractDeployer):
         # Deposit
         # TODO: Gas management
         args = {'from': self.deployer_address,
-                'gasPrice': self.blockchain.w3.eth.gasPrice,
+                'gasPrice': self.blockchain.client.gasPrice,
                 'gas': 200_000}
         deposit_function = self.contract.functions.initialDeposit(value, duration)
         deposit_receipt = self.blockchain.send_transaction(transaction_function=deposit_function,

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -156,8 +156,8 @@ class BlockchainInterface:
         self.log = Logger('Blockchain')
         self.poa = poa
         self.provider_uri = provider_uri
-        self.__provider = provider
-        self.__provider_process = provider_process
+        self._provider = provider
+        self._provider_process = provider_process
         self.client = NO_BLOCKCHAIN_CONNECTION
         self.transacting_power = transacting_power
         self.registry = registry
@@ -187,10 +187,10 @@ class BlockchainInterface:
         return self.client.is_connected
 
     def disconnect(self):
-        if self.__provider_process:
-            self.__provider_process.stop()
-        self.__provider_process = NO_BLOCKCHAIN_CONNECTION
-        self.__provider = NO_BLOCKCHAIN_CONNECTION
+        if self._provider_process:
+            self._provider_process.stop()
+        self._provider_process = NO_BLOCKCHAIN_CONNECTION
+        self._provider = NO_BLOCKCHAIN_CONNECTION
 
     def attach_middleware(self):
 
@@ -206,21 +206,21 @@ class BlockchainInterface:
                   sync_now: bool = True):
 
         # Spawn child process
-        if self.__provider_process:
-            self.__provider_process.start()
-            provider_uri = self.__provider_process.provider_uri(scheme='file')
+        if self._provider_process:
+            self._provider_process.start()
+            provider_uri = self._provider_process.provider_uri(scheme='file')
         else:
             self.log.info(f"Using external Web3 Provider '{provider_uri}'")
 
         # Attach Provider
         self._attach_provider(provider=provider, provider_uri=provider_uri)
         self.log.info("Connecting to {}".format(self.provider_uri))
-        if self.__provider is NO_BLOCKCHAIN_CONNECTION:
+        if self._provider is NO_BLOCKCHAIN_CONNECTION:
             raise self.NoProvider("There are no configured blockchain providers")
 
         # Connect Web3 Instance
         try:
-            self.w3 = self.Web3(provider=self.__provider)
+            self.w3 = self.Web3(provider=self._provider)
             self.client = Web3Client.from_w3(w3=self.w3)
         except requests.ConnectionError:  # RPC
             raise self.ConnectionFailed(f'Connection Failed - {str(self.provider_uri)} - is RPC enabled?')
@@ -269,13 +269,13 @@ class BlockchainInterface:
                 }
                 provider_scheme = uri_breakdown.scheme
             try:
-                self.__provider = providers[provider_scheme](provider_uri)
+                self._provider = providers[provider_scheme](provider_uri)
             except KeyError:
                 raise ValueError(f"{provider_uri} is an invalid or unsupported blockchain provider URI")
             else:
                 self.provider_uri = provider_uri or NO_BLOCKCHAIN_CONNECTION
         else:
-            self.__provider = provider
+            self._provider = provider
 
     def send_transaction(self,
                          transaction_function: ContractFunction,

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -197,7 +197,7 @@ class BlockchainInterface:
         # For use with Proof-Of-Authority test-blockchains
         if self.poa is True:
             self.log.debug('Injecting POA middleware at layer 0')
-            self.client.w3.middleware_onion.inject(geth_poa_middleware, layer=0)
+            self.client.inject_middleware(geth_poa_middleware, layer=0)
 
     def __connect(self,
                   provider: Web3Providers = None,

--- a/nucypher/blockchain/eth/policies.py
+++ b/nucypher/blockchain/eth/policies.py
@@ -275,7 +275,7 @@ class BlockchainPolicy(Policy):
         payload = {'from': self.author.checksum_address,
                    'value': self.value,
                    'gas': 500_000,  # TODO: Gas management
-                   'gasPrice': self.author.blockchain.w3.eth.gasPrice}
+                   'gasPrice': self.author.blockchain.client.gasPrice}
 
         prearranged_ursulas = list(a.ursula.checksum_address for a in self._accepted_arrangements)
         policy_args = (self.hrac()[:16],     # bytes16 _policyID

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -379,8 +379,8 @@ class Felix(Character, NucypherTokenActor):
             transaction = {'to': recipient_address,
                            'from': self.checksum_address,
                            'value': ether,
-                           'gasPrice': self.blockchain.w3.eth.gasPrice}
-            ether_txhash = self.blockchain.w3.eth.sendTransaction(transaction)
+                           'gasPrice': self.blockchain.client.gasPrice}
+            ether_txhash = self.blockchain.client.sendTransaction(transaction)
 
             self.log.info(f"Disbursement #{self.__disbursement} OK | NU {txhash.hex()[-6:]} | ETH {ether_txhash.hex()[:6]} "
                           f"({str(NU(disbursement, 'NuNit'))} + {self.ETHER_AIRDROP_AMOUNT} wei) -> {recipient_address}")

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -63,7 +63,7 @@ class Vladimir(Ursula):
                        ######### Asshole.
                        timestamp=target_ursula._timestamp,
                        interface_signature=target_ursula._interface_signature,
-                       ######### 
+                       #########
                        )
 
         return vladimir
@@ -78,7 +78,7 @@ class Vladimir(Ursula):
             blockchain.w3.provider.ethereum_tester.add_account(cls.fraud_key, password=password)
         except (ValidationError, ):
             # check if Vlad's key is already on the keyring...
-            if cls.fraud_address in blockchain.w3.eth.accounts:
+            if cls.fraud_address in blockchain.client.accounts:
                 return True
             else:
                 raise

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -138,7 +138,7 @@ def felix(click_config,
                                                federated_only=felix_config.federated_only,
                                                network_domains=felix_config.domains,
                                                network_middleware=click_config.middleware)
-        
+
         # Add ETH Bootnode or Peer
         if enode:
             if geth:
@@ -178,7 +178,7 @@ ETH ........ {str(eth_balance)}
         """)
 
     elif action == "accounts":
-        accounts = FELIX.blockchain.w3.eth.accounts
+        accounts = FELIX.blockchain.client.accounts
         for account in accounts:
             click.secho(account)
 

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -329,7 +329,7 @@ def ursula(click_config,
             click.secho(f'Block # {current_block}')
             click.secho(f'NU Balance: {URSULA.token_balance}')
             click.secho(f'ETH Balance: {URSULA.eth_balance}')
-            click.secho(f'Current Gas Price {URSULA.blockchain.w3.eth.gasPrice}')
+            click.secho(f'Current Gas Price {URSULA.blockchain.client.gasPrice}')
 
         click.secho("CONFIGURATION --------")
         response = UrsulaConfiguration._read_configuration_file(filepath=config_file or ursula_config.config_file_location)

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -112,7 +112,7 @@ class NucypherClickConfig:
         # Ethereum Client  # TODO : Integrate with Powers API
         if not character_configuration.federated_only and unlock_wallet:
             self.emit(message='Decrypting Ethereum Node Keyring...', color='yellow')
-            character_configuration.blockchain.unlock_account(address=character_configuration.checksum_address,
+            character_configuration.blockchain.client.unlock_account(address=character_configuration.checksum_address,
                                                                         password=password)
 
     @classmethod

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -118,11 +118,11 @@ def deploy(click_config,
     #
 
     if not deployer_address:
-        for index, address in enumerate(blockchain.w3.eth.accounts):
+        for index, address in enumerate(blockchain.client.accounts):
             click.secho(f"{index} --- {address}")
-        choices = click.IntRange(0, len(blockchain.w3.eth.accounts))
+        choices = click.IntRange(0, len(blockchain.client.accounts))
         deployer_address_index = click.prompt("Select deployer address", default=0, type=choices)
-        deployer_address = blockchain.w3.eth.accounts[deployer_address_index]
+        deployer_address = blockchain.client.accounts[deployer_address_index]
 
     # Verify Address
     if not force:
@@ -135,10 +135,10 @@ def deploy(click_config,
         click.secho("Deployer address has no ETH.", fg='red', bold=True)
         raise click.Abort()
 
-    if not blockchain.is_local:
+    if not blockchain.client.is_local:
         # (~ dev mode; Assume accounts are already unlocked)
         password = click.prompt("Enter ETH node password", hide_input=True)
-        blockchain.w3.geth.personal.unlockAccount(deployer_address, password)
+        blockchain.client.unlockAccount(deployer_address, password)
 
     # Add ETH Bootnode or Peer
     if enode:
@@ -220,8 +220,8 @@ def deploy(click_config,
 
         click.secho(f"Deployer Address .... {deployer.checksum_address}")
         click.secho(f"ETH ................. {deployer.eth_balance}")
-        click.secho(f"Chain ID ............ {deployer.blockchain.chain_id}")
-        click.secho(f"Chain Name .......... {deployer.blockchain.chain_name}")
+        click.secho(f"Chain ID ............ {deployer.blockchain.client.chain_id}")
+        click.secho(f"Chain Name .......... {deployer.blockchain.client.chain_name}")
 
         # Ask - Last chance to gracefully abort
         if not force:

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -198,7 +198,7 @@ Gas Price ................ {gas_price}
 Active Staking Ursulas ... {ursulas}
 
     """.format(period=ursula_config.staking_agent.get_current_period(),
-               gas_price=ursula_config.blockchain.w3.eth.gasPrice,
+               gas_price=ursula_config.blockchain.client.gasPrice,
                ursulas=ursula_config.staking_agent.get_staker_population())
     click.secho(network_payload)
 

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -284,7 +284,7 @@ class CharacterConfiguration(BaseConfiguration):
             if not os.path.exists(path):
                 message = 'Missing configuration file or directory: {}.'
                 if 'registry' in path:
-                    message += ' Did you mean to pass --federated-only?'                    
+                    message += ' Did you mean to pass --federated-only?'
                 raise CharacterConfiguration.InvalidConfiguration(message.format(path))
         return True
 
@@ -444,7 +444,7 @@ class CharacterConfiguration(BaseConfiguration):
                 self.connect_to_blockchain()
                 if not self.blockchain.client.accounts:
                     raise self.ConfigurationError(f'Web3 provider "{self.provider_uri}" does not have any accounts')
-                self.checksum_address = self.blockchain.etherbase
+                self.checksum_address = self.blockchain.client.etherbase
 
         self.keyring = NucypherKeyring.generate(password=password,
                                                 keyring_root=self.keyring_root,

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -193,7 +193,7 @@ class CharacterConfiguration(BaseConfiguration):
                                               sync_now=sync_now)
 
         # Read Ethereum Node Keyring
-        self.accounts = self.blockchain.w3.eth.accounts
+        self.accounts = self.blockchain.client.accounts
 
     def connect_to_contracts(self) -> None:
         self.token_agent = NucypherTokenAgent(blockchain=self.blockchain)

--- a/nucypher/utilities/sandbox/blockchain.py
+++ b/nucypher/utilities/sandbox/blockchain.py
@@ -48,7 +48,7 @@ def token_airdrop(token_agent, amount: NU, origin: str, addresses: List[str]):
     """Airdrops tokens from creator address to all other addresses!"""
 
     def txs():
-        args = {'from': origin, 'gasPrice': token_agent.blockchain.w3.eth.gasPrice}
+        args = {'from': origin, 'gasPrice': token_agent.blockchain.client.gasPrice}
         for address in addresses:
             txhash = token_agent.contract.functions.transfer(address, int(amount)).transact(args)
             yield txhash
@@ -204,13 +204,13 @@ class TesterBlockchain(BlockchainDeployerInterface):
 
     @property
     def provider(self) -> Union[IPCProvider, WebsocketProvider, HTTPProvider]:
-        return self.__provider
+        return self._provider
 
     @classmethod
     def bootstrap_network(cls) -> Tuple['TesterBlockchain', Dict[str, EthereumContractAgent]]:
         testerchain = cls.connect()
 
-        origin = testerchain.w3.eth.accounts[0]
+        origin = testerchain.client.accounts[0]
         deployer = Deployer(blockchain=testerchain, deployer_address=origin, bare=True)
 
         _txhashes, agents = deployer.deploy_network_contracts(staker_secret=STAKING_ESCROW_DEPLOYMENT_SECRET,
@@ -221,25 +221,25 @@ class TesterBlockchain(BlockchainDeployerInterface):
 
     @property
     def etherbase_account(self):
-        return self.w3.eth.accounts[self._ETHERBASE]
+        return self.client.accounts[self._ETHERBASE]
 
     @property
     def alice_account(self):
-        return self.w3.eth.accounts[self._ALICE]
+        return self.client.accounts[self._ALICE]
 
     @property
     def bob_account(self):
-        return self.w3.eth.accounts[self._BOB]
+        return self.client.accounts[self._BOB]
 
     def ursula_account(self, index):
         if index not in self._ursulas_range:
             raise ValueError(f"Ursula index must be lower than {NUMBER_OF_URSULAS_IN_BLOCKCHAIN_TESTS}")
-        return self.w3.eth.accounts[index + self._FIRST_URSULA]
+        return self.client.accounts[index + self._FIRST_URSULA]
 
     def staker_account(self, index):
         if index not in self._stakers_range:
             raise ValueError(f"Staker index must be lower than {NUMBER_OF_STAKERS_IN_BLOCKCHAIN_TESTS}")
-        return self.w3.eth.accounts[index + self._FIRST_STAKER]
+        return self.client.accounts[index + self._FIRST_STAKER]
 
     @property
     def ursulas_accounts(self):
@@ -253,7 +253,7 @@ class TesterBlockchain(BlockchainDeployerInterface):
     def unassigned_accounts(self):
         special_accounts = [self.etherbase_account, self.alice_account, self.bob_account]
         assigned_accounts = set(self.stakers_accounts + self.ursulas_accounts + special_accounts)
-        accounts = set(self.w3.eth.accounts)
+        accounts = set(self.client.accounts)
         return list(accounts.difference(assigned_accounts))
 
     def wait_for_receipt(self, txhash: bytes, timeout: int = None) -> dict:

--- a/tests/blockchain/eth/clients/test_mocked_clients.py
+++ b/tests/blockchain/eth/clients/test_mocked_clients.py
@@ -88,29 +88,29 @@ class GanacheClientTestInterface(BlockchainInterfaceTestBase):
 def test_geth_web3_client():
     interface = GethClientTestBlockchain(provider_uri='file:///ipc.geth', sync_now=False)
     assert isinstance(interface.client, GethClient)
-    assert interface.node_technology == 'Geth'
-    assert interface.node_version == 'v1.4.11-stable-fed692f6'
-    assert interface.platform == 'darwin'
-    assert interface.backend == 'go1.7'
+    assert interface.client.node_technology == 'Geth'
+    assert interface.client.node_version == 'v1.4.11-stable-fed692f6'
+    assert interface.client.platform == 'darwin'
+    assert interface.client.backend == 'go1.7'
 
-    assert interface.is_local is False
-    assert interface.chain_id == 5
+    assert interface.client.is_local is False
+    assert interface.client.chain_id == 5
 
 
 def test_parity_web3_client():
     interface = ParityClientTestInterface(provider_uri='file:///ipc.parity', sync_now=False)
     assert isinstance(interface.client, ParityClient)
-    assert interface.node_technology == 'Parity-Ethereum'
-    assert interface.node_version == 'v2.5.1-beta-e0141f8-20190510'
-    assert interface.platform == 'x86_64-linux-gnu'
-    assert interface.backend == 'rustc1.34.1'
+    assert interface.client.node_technology == 'Parity-Ethereum'
+    assert interface.client.node_version == 'v2.5.1-beta-e0141f8-20190510'
+    assert interface.client.platform == 'x86_64-linux-gnu'
+    assert interface.client.backend == 'rustc1.34.1'
 
 
 def test_ganache_web3_client():
     interface = GanacheClientTestInterface(provider_uri='http://ganache:8445', sync_now=False)
     assert isinstance(interface.client, GanacheClient)
-    assert interface.node_technology == 'EthereumJS TestRPC'
-    assert interface.node_version == 'v2.1.5'
-    assert interface.platform is None
-    assert interface.backend == 'ethereum-js'
-    assert interface.is_local
+    assert interface.client.node_technology == 'EthereumJS TestRPC'
+    assert interface.client.node_version == 'v2.1.5'
+    assert interface.client.platform is None
+    assert interface.client.backend == 'ethereum-js'
+    assert interface.client.is_local

--- a/tests/blockchain/eth/contracts/base/seeder/test_seeder.py
+++ b/tests/blockchain/eth/contracts/base/seeder/test_seeder.py
@@ -27,7 +27,7 @@ from nucypher.utilities.sandbox.constants import MOCK_IP_ADDRESS, MOCK_IP_ADDRES
 
 @pytest.mark.slow()
 def test_seeder(testerchain):
-    origin, seed_address, another_seed_address, *everyone_else = testerchain.w3.eth.accounts
+    origin, seed_address, another_seed_address, *everyone_else = testerchain.client.accounts
     seed = (MOCK_IP_ADDRESS, MOCK_URSULA_STARTING_PORT)
     another_seed = (MOCK_IP_ADDRESS_2, MOCK_URSULA_STARTING_PORT + 1)
 

--- a/tests/blockchain/eth/contracts/base/test_dispatcher.py
+++ b/tests/blockchain/eth/contracts/base/test_dispatcher.py
@@ -18,6 +18,7 @@ import os
 
 import pytest
 from eth_tester.exceptions import TransactionFailed
+from eth_utils import keccak
 from web3.contract import Contract
 from web3.exceptions import BadFunctionCallOutput
 
@@ -28,15 +29,15 @@ SECRET_LENGTH = 16
 
 @pytest.mark.slow
 def test_dispatcher(testerchain):
-    creator = testerchain.w3.eth.accounts[0]
-    account = testerchain.w3.eth.accounts[1]
+    creator = testerchain.client.accounts[0]
+    account = testerchain.client.accounts[1]
 
     secret = os.urandom(SECRET_LENGTH)
-    secret_hash = testerchain.w3.keccak(secret)
+    secret_hash = keccak(secret)
     secret2 = os.urandom(SECRET_LENGTH)
-    secret2_hash = testerchain.w3.keccak(secret2)
+    secret2_hash = keccak(secret2)
     secret3 = os.urandom(SECRET_LENGTH)
-    secret3_hash = testerchain.w3.keccak(secret3)
+    secret3_hash = keccak(secret3)
 
     # Try to deploy broken libraries and dispatcher for them
     contract0_bad_lib, _ = testerchain.deploy_contract('BadDispatcherStorage')
@@ -80,7 +81,7 @@ def test_dispatcher(testerchain):
 
     # Assign dispatcher address as contract.
     # In addition to the interface can be used ContractV1, ContractV2 or ContractV3 ABI
-    contract_instance = testerchain.w3.eth.contract(
+    contract_instance = testerchain.client.get_contract(
         abi=contract1_lib.abi,
         address=dispatcher.address,
         ContractFactoryClass=Contract)
@@ -219,7 +220,7 @@ def test_dispatcher(testerchain):
     assert 'Hello' == contract_instance.functions.dynamicallySizedValue().call()
 
     # Changes ABI to ContractV2 for using additional methods
-    contract_instance = testerchain.w3.eth.contract(
+    contract_instance = testerchain.client.get_contract(
         abi=contract2_lib.abi,
         address=dispatcher.address,
         ContractFactoryClass=Contract)
@@ -306,7 +307,7 @@ def test_dispatcher(testerchain):
     assert contract1_lib.address == dispatcher.functions.target().call()
 
     # Create Event
-    contract_instance = testerchain.w3.eth.contract(
+    contract_instance = testerchain.client.get_contract(
         abi=contract1_lib.abi,
         address=dispatcher.address,
         ContractFactoryClass=Contract)
@@ -322,7 +323,7 @@ def test_dispatcher(testerchain):
     testerchain.wait_for_receipt(tx)
     tx = dispatcher.functions.upgrade(contract3_lib.address, secret, secret2_hash).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    contract_instance = testerchain.w3.eth.contract(
+    contract_instance = testerchain.client.get_contract(
         abi=contract3_lib.abi,
         address=dispatcher.address,
         ContractFactoryClass=Contract)
@@ -388,7 +389,7 @@ def test_dispatcher(testerchain):
     assert 1 == len(events)
     assert 22 == events[0]['args']['value']
 
-    contract_instance = testerchain.w3.eth.contract(
+    contract_instance = testerchain.client.get_contract(
         abi=contract1_lib.abi,
         address=dispatcher.address,
         ContractFactoryClass=Contract)
@@ -400,7 +401,7 @@ def test_dispatcher(testerchain):
     # Check upgrading to the contract with explicit storage slots
     tx = dispatcher.functions.upgrade(contract4_lib.address, secret2, secret3_hash).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    contract_instance = testerchain.w3.eth.contract(
+    contract_instance = testerchain.client.get_contract(
         abi=contract4_lib.abi,
         address=dispatcher.address,
         ContractFactoryClass=Contract)
@@ -472,15 +473,15 @@ def test_dispatcher(testerchain):
 
 @pytest.mark.slow
 def test_selfdestruct(testerchain):
-    creator = testerchain.w3.eth.accounts[0]
-    account = testerchain.w3.eth.accounts[1]
+    creator = testerchain.client.accounts[0]
+    account = testerchain.client.accounts[1]
 
     secret = os.urandom(SECRET_LENGTH)
-    secret_hash = testerchain.w3.keccak(secret)
+    secret_hash = keccak(secret)
     secret2 = os.urandom(SECRET_LENGTH)
-    secret2_hash = testerchain.w3.keccak(secret2)
+    secret2_hash = keccak(secret2)
     secret3 = os.urandom(SECRET_LENGTH)
-    secret3_hash = testerchain.w3.keccak(secret3)
+    secret3_hash = keccak(secret3)
 
     # Deploy contract and destroy it
     contract1_lib, _ = testerchain.deploy_contract('Destroyable', 22)
@@ -503,7 +504,7 @@ def test_selfdestruct(testerchain):
     dispatcher, _ = testerchain.deploy_contract('Dispatcher', contract2_lib.address, secret_hash)
     assert contract2_lib.address == dispatcher.functions.target().call()
 
-    contract_instance = testerchain.w3.eth.contract(
+    contract_instance = testerchain.client.get_contract(
         abi=contract1_lib.abi,
         address=dispatcher.address,
         ContractFactoryClass=Contract)

--- a/tests/blockchain/eth/contracts/base/test_issuer.py
+++ b/tests/blockchain/eth/contracts/base/test_issuer.py
@@ -32,8 +32,8 @@ def token(testerchain):
 
 @pytest.mark.slow
 def test_issuer(testerchain, token):
-    creator = testerchain.w3.eth.accounts[0]
-    ursula = testerchain.w3.eth.accounts[1]
+    creator = testerchain.client.accounts[0]
+    ursula = testerchain.client.accounts[1]
 
     # Only token contract is allowed in Issuer constructor
     with pytest.raises((TransactionFailed, ValueError)):
@@ -97,8 +97,8 @@ def test_inflation_rate(testerchain, token):
     During one period inflation rate must be the same
     """
 
-    creator = testerchain.w3.eth.accounts[0]
-    ursula = testerchain.w3.eth.accounts[1]
+    creator = testerchain.client.accounts[0]
+    ursula = testerchain.client.accounts[1]
 
     # Creator deploys the contract
     issuer, _ = testerchain.deploy_contract('IssuerMock', token.address, 1, 2 * 10 ** 19, 1, 1)
@@ -158,7 +158,7 @@ def test_inflation_rate(testerchain, token):
 
 @pytest.mark.slow
 def test_upgrading(testerchain, token):
-    creator = testerchain.w3.eth.accounts[0]
+    creator = testerchain.client.accounts[0]
 
     secret = os.urandom(SECRET_LENGTH)
     secret_hash = testerchain.w3.keccak(secret)
@@ -171,7 +171,7 @@ def test_upgrading(testerchain, token):
 
     # Deploy second version of the contract
     contract_library_v2, _ = testerchain.deploy_contract('IssuerV2Mock', token.address, 2, 2, 2, 2)
-    contract = testerchain.w3.eth.contract(
+    contract = testerchain.client.get_contract(
         abi=contract_library_v2.abi,
         address=dispatcher.address,
         ContractFactoryClass=Contract)

--- a/tests/blockchain/eth/contracts/base/test_multisig.py
+++ b/tests/blockchain/eth/contracts/base/test_multisig.py
@@ -64,8 +64,8 @@ def test_execute(testerchain):
     assert not multisig.functions.isOwner(others[1]).call()
 
     # Transfer ETH to the multisig contract
-    tx = testerchain.w3.eth.sendTransaction(
-        {'from': testerchain.w3.eth.coinbase, 'to': multisig.address, 'value': 200})
+    tx = testerchain.client.sendTransaction(
+        {'from': testerchain.client.coinbase, 'to': multisig.address, 'value': 200})
     testerchain.wait_for_receipt(tx)
     assert 200 == w3.eth.getBalance(multisig.address)
 

--- a/tests/blockchain/eth/contracts/main/adjudicator/conftest.py
+++ b/tests/blockchain/eth/contracts/main/adjudicator/conftest.py
@@ -42,7 +42,7 @@ def adjudicator_contract(testerchain, escrow, request, slashing_economics):
         dispatcher, _ = testerchain.deploy_contract('Dispatcher', contract.address, secret_hash)
 
         # Deploy second version of the government contract
-        contract = testerchain.w3.eth.contract(
+        contract = testerchain.client.get_contract(
             abi=contract.abi,
             address=dispatcher.address,
             ContractFactoryClass=Contract)

--- a/tests/blockchain/eth/contracts/main/adjudicator/test_adjudicator.py
+++ b/tests/blockchain/eth/contracts/main/adjudicator/test_adjudicator.py
@@ -22,7 +22,7 @@ import pytest
 from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives import hashes
 from eth_tester.exceptions import TransactionFailed
-from eth_utils import to_canonical_address
+from eth_utils import to_canonical_address, keccak
 from typing import Tuple
 from web3.contract import Contract
 
@@ -55,7 +55,7 @@ def test_evaluate_cfrag(testerchain,
                         mock_ursula_reencrypts
                         ):
     ursula = list(federated_ursulas)[0]
-    creator, staker, wrong_staker, investigator, *everyone_else = testerchain.w3.eth.accounts
+    creator, staker, wrong_staker, investigator, *everyone_else = testerchain.client.accounts
     evaluation_log = adjudicator_contract.events.CFragEvaluated.createFilter(fromBlock='latest')
     verdict_log = adjudicator_contract.events.IncorrectCFragVerdict.createFilter(fromBlock='latest')
 
@@ -419,10 +419,10 @@ def test_evaluate_cfrag(testerchain,
 
 @pytest.mark.slow
 def test_upgrading(testerchain):
-    creator = testerchain.w3.eth.accounts[0]
+    creator = testerchain.client.accounts[0]
 
-    secret_hash = testerchain.w3.keccak(secret)
-    secret2_hash = testerchain.w3.keccak(secret2)
+    secret_hash = keccak(secret)
+    secret2_hash = keccak(secret2)
 
     # Only escrow contract is allowed in Adjudicator constructor
     with pytest.raises((TransactionFailed, ValueError)):
@@ -440,7 +440,7 @@ def test_upgrading(testerchain):
     # Deploy second version of the contract
     contract_library_v2, _ = testerchain.deploy_contract(
         'AdjudicatorV2Mock', address2, ALGORITHM_SHA256, 5, 6, 7, 8)
-    contract = testerchain.w3.eth.contract(
+    contract = testerchain.client.get_contract(
         abi=contract_library_v2.abi,
         address=dispatcher.address,
         ContractFactoryClass=Contract)

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager_operations.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager_operations.py
@@ -46,8 +46,8 @@ value = rate * number_of_periods
 
 @pytest.mark.slow
 def test_reward(testerchain, escrow, policy_manager):
-    creator, client, bad_node, node1, node2, node3, *everyone_else = testerchain.w3.eth.accounts
-    node_balance = testerchain.w3.eth.getBalance(node1)
+    creator, client, bad_node, node1, node2, node3, *everyone_else = testerchain.client.accounts
+    node_balance = testerchain.client.get_balance(node1)
     withdraw_log = policy_manager.events.Withdrawn.createFilter(fromBlock='latest')
 
     # Mint period without policies
@@ -84,8 +84,8 @@ def test_reward(testerchain, escrow, policy_manager):
     # Withdraw some ETH
     tx = policy_manager.functions.withdraw().transact({'from': node1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert node_balance + 80 == testerchain.w3.eth.getBalance(node1)
-    assert 120 + value == testerchain.w3.eth.getBalance(policy_manager.address)
+    assert node_balance + 80 == testerchain.client.get_balance(node1)
+    assert 120 + value == testerchain.client.get_balance(policy_manager.address)
 
     events = withdraw_log.get_all_entries()
     assert 1 == len(events)
@@ -107,8 +107,8 @@ def test_reward(testerchain, escrow, policy_manager):
     # Withdraw some ETH
     tx = policy_manager.functions.withdraw(node1).transact({'from': node1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert node_balance + value == testerchain.w3.eth.getBalance(node1)
-    assert value == testerchain.w3.eth.getBalance(policy_manager.address)
+    assert node_balance + value == testerchain.client.get_balance(node1)
+    assert value == testerchain.client.get_balance(policy_manager.address)
 
     events = withdraw_log.get_all_entries()
     assert 2 == len(events)
@@ -137,13 +137,13 @@ def test_reward(testerchain, escrow, policy_manager):
     assert 210 == policy_manager.functions.nodes(node2).call()[REWARD_FIELD]
 
     # Withdraw ETH for first node
-    node_balance = testerchain.w3.eth.getBalance(node1)
-    node_2_balance = testerchain.w3.eth.getBalance(node2)
+    node_balance = testerchain.client.get_balance(node1)
+    node_2_balance = testerchain.client.get_balance(node2)
     tx = policy_manager.functions.withdraw(node1).transact({'from': node2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert node_balance + 210 == testerchain.w3.eth.getBalance(node1)
-    assert node_2_balance == testerchain.w3.eth.getBalance(node2)
-    assert value + 210 == testerchain.w3.eth.getBalance(policy_manager.address)
+    assert node_balance + 210 == testerchain.client.get_balance(node1)
+    assert node_2_balance == testerchain.client.get_balance(node2)
+    assert value + 210 == testerchain.client.get_balance(policy_manager.address)
 
     events = withdraw_log.get_all_entries()
     assert 3 == len(events)
@@ -155,12 +155,12 @@ def test_reward(testerchain, escrow, policy_manager):
 
 @pytest.mark.slow
 def test_refund(testerchain, escrow, policy_manager):
-    creator = testerchain.w3.eth.accounts[0]
-    client = testerchain.w3.eth.accounts[1]
-    node1 = testerchain.w3.eth.accounts[3]
-    node2 = testerchain.w3.eth.accounts[4]
-    node3 = testerchain.w3.eth.accounts[5]
-    client_balance = testerchain.w3.eth.getBalance(client)
+    creator = testerchain.client.accounts[0]
+    client = testerchain.client.accounts[1]
+    node1 = testerchain.client.accounts[3]
+    node2 = testerchain.client.accounts[4]
+    node3 = testerchain.client.accounts[5]
+    client_balance = testerchain.client.get_balance(client)
     policy_created_log = policy_manager.events.PolicyCreated.createFilter(fromBlock='latest')
     arrangement_revoked_log = policy_manager.events.ArrangementRevoked.createFilter(fromBlock='latest')
     policy_revoked_log = policy_manager.events.PolicyRevoked.createFilter(fromBlock='latest')
@@ -180,16 +180,16 @@ def test_refund(testerchain, escrow, policy_manager):
     testerchain.wait_for_receipt(tx)
     tx = policy_manager.functions.calculateRefundValue(policy_id, node1).transact({'from': client, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 210 == testerchain.w3.eth.getBalance(policy_manager.address)
-    assert client_balance - 210 == testerchain.w3.eth.getBalance(client)
+    assert 210 == testerchain.client.get_balance(policy_manager.address)
+    assert client_balance - 210 == testerchain.client.get_balance(client)
     assert 190 == policy_manager.functions.calculateRefundValue(policy_id, node1).call({'from': client})
     assert 190 == policy_manager.functions.calculateRefundValue(policy_id).call({'from': client})
 
     # Call refund, the result must be almost all ETH without payment for one period
     tx = policy_manager.functions.refund(policy_id).transact({'from': client, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 20 == testerchain.w3.eth.getBalance(policy_manager.address)
-    assert client_balance - 20 == testerchain.w3.eth.getBalance(client)
+    assert 20 == testerchain.client.get_balance(policy_manager.address)
+    assert client_balance - 20 == testerchain.client.get_balance(client)
     assert client == policy_manager.functions.policies(policy_id).call()[CLIENT_FIELD]
 
     events = arrangement_refund_log.get_all_entries()
@@ -214,8 +214,8 @@ def test_refund(testerchain, escrow, policy_manager):
     # Call refund, last period must be refunded
     tx = policy_manager.functions.refund(policy_id).transact({'from': client, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 0 == testerchain.w3.eth.getBalance(policy_manager.address)
-    assert client_balance == testerchain.w3.eth.getBalance(client)
+    assert 0 == testerchain.client.get_balance(policy_manager.address)
+    assert client_balance == testerchain.client.get_balance(client)
     assert policy_manager.functions.policies(policy_id).call()[DISABLED_FIELD]
 
     events = arrangement_refund_log.get_all_entries()
@@ -270,8 +270,8 @@ def test_refund(testerchain, escrow, policy_manager):
     testerchain.wait_for_receipt(tx)
     tx = policy_manager.functions.refund(policy_id_2, node1).transact({'from': client, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 3 * value + 1.5 * rate == testerchain.w3.eth.getBalance(policy_manager.address)
-    assert client_balance - int(3 * value + 1.5 * rate) == testerchain.w3.eth.getBalance(client)
+    assert 3 * value + 1.5 * rate == testerchain.client.get_balance(policy_manager.address)
+    assert client_balance - int(3 * value + 1.5 * rate) == testerchain.client.get_balance(client)
 
     events = arrangement_refund_log.get_all_entries()
     assert 5 == len(events)
@@ -344,8 +344,8 @@ def test_refund(testerchain, escrow, policy_manager):
     # Refund for only inactive periods
     tx = policy_manager.functions.refund(policy_id_2, node1).transact({'from': client, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 2 * value + 90 + rate == testerchain.w3.eth.getBalance(policy_manager.address)
-    assert client_balance - (2 * value + 90 + rate) == testerchain.w3.eth.getBalance(client)
+    assert 2 * value + 90 + rate == testerchain.client.get_balance(policy_manager.address)
+    assert client_balance - (2 * value + 90 + rate) == testerchain.client.get_balance(client)
     assert not policy_manager.functions.policies(policy_id_2).call()[DISABLED_FIELD]
 
     events = arrangement_refund_log.get_all_entries()
@@ -379,8 +379,8 @@ def test_refund(testerchain, escrow, policy_manager):
     assert 120 == policy_manager.functions.calculateRefundValue(policy_id_2, node3).call({'from': client})
     tx = policy_manager.functions.refund(policy_id_2).transact({'from': client, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 3 * 90 == testerchain.w3.eth.getBalance(policy_manager.address)
-    assert client_balance - 3 * 90 == testerchain.w3.eth.getBalance(client)
+    assert 3 * 90 == testerchain.client.get_balance(policy_manager.address)
+    assert client_balance - 3 * 90 == testerchain.client.get_balance(client)
     assert policy_manager.functions.policies(policy_id_2).call()[DISABLED_FIELD]
 
     events = arrangement_refund_log.get_all_entries()
@@ -433,8 +433,8 @@ def test_refund(testerchain, escrow, policy_manager):
 
     tx = policy_manager.functions.revokePolicy(policy_id_3).transact({'from': client, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 60 + 3 * 90 == testerchain.w3.eth.getBalance(policy_manager.address)
-    assert client_balance - (60 + 3 * 90) == testerchain.w3.eth.getBalance(client)
+    assert 60 + 3 * 90 == testerchain.client.get_balance(policy_manager.address)
+    assert client_balance - (60 + 3 * 90) == testerchain.client.get_balance(client)
     assert policy_manager.functions.policies(policy_id_3).call()[DISABLED_FIELD]
 
     events = arrangement_refund_log.get_all_entries()

--- a/tests/blockchain/eth/contracts/main/staking_escrow/conftest.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/conftest.py
@@ -18,6 +18,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
 from web3.contract import Contract
+from eth_utils import keccak
 
 from nucypher.blockchain.eth.token import NU
 
@@ -52,9 +53,9 @@ def escrow_contract(testerchain, token, request):
         )
 
         if request.param:
-            secret_hash = testerchain.w3.keccak(secret)
+            secret_hash = keccak(secret)
             dispatcher, _ = testerchain.deploy_contract('Dispatcher', contract.address, secret_hash)
-            contract = testerchain.w3.eth.contract(
+            contract = testerchain.client.get_contract(
                 abi=contract.abi,
                 address=dispatcher.address,
                 ContractFactoryClass=Contract)

--- a/tests/blockchain/eth/contracts/main/staking_escrow/test_staking.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/test_staking.py
@@ -25,13 +25,13 @@ from web3.contract import Contract
 def test_mining(testerchain, token, escrow_contract):
     escrow = escrow_contract(1500)
     policy_manager_interface = testerchain.get_contract_factory('PolicyManagerForStakingEscrowMock')
-    policy_manager = testerchain.w3.eth.contract(
+    policy_manager = testerchain.client.get_contract(
         abi=policy_manager_interface.abi,
         address=escrow.functions.policyManager().call(),
         ContractFactoryClass=Contract)
-    creator = testerchain.w3.eth.accounts[0]
-    ursula1 = testerchain.w3.eth.accounts[1]
-    ursula2 = testerchain.w3.eth.accounts[2]
+    creator = testerchain.client.accounts[0]
+    ursula1 = testerchain.client.accounts[1]
+    ursula2 = testerchain.client.accounts[2]
 
     staking_log = escrow.events.Mined.createFilter(fromBlock='latest')
     deposit_log = escrow.events.Deposited.createFilter(fromBlock='latest')
@@ -314,9 +314,9 @@ def test_slashing(testerchain, token, escrow_contract):
     )
     tx = escrow.functions.setAdjudicator(adjudicator.address).transact()
     testerchain.wait_for_receipt(tx)
-    creator = testerchain.w3.eth.accounts[0]
-    ursula = testerchain.w3.eth.accounts[1]
-    investigator = testerchain.w3.eth.accounts[2]
+    creator = testerchain.client.accounts[0]
+    ursula = testerchain.client.accounts[1]
+    investigator = testerchain.client.accounts[2]
 
     slashing_log = escrow.events.Slashed.createFilter(fromBlock='latest')
 
@@ -620,7 +620,7 @@ def test_slashing(testerchain, token, escrow_contract):
     assert 0 == event_args['reward']
 
     # Prepare second Ursula for tests
-    ursula2 = testerchain.w3.eth.accounts[3]
+    ursula2 = testerchain.client.accounts[3]
     tx = token.functions.transfer(ursula2, 10000).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     tx = token.functions.approve(escrow.address, 10000).transact({'from': ursula2})

--- a/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow.py
@@ -30,9 +30,9 @@ def test_staking(testerchain, token, escrow_contract):
     """
 
     escrow = escrow_contract(1500)
-    creator = testerchain.w3.eth.accounts[0]
-    ursula1 = testerchain.w3.eth.accounts[1]
-    ursula2 = testerchain.w3.eth.accounts[2]
+    creator = testerchain.client.accounts[0]
+    ursula1 = testerchain.client.accounts[1]
+    ursula2 = testerchain.client.accounts[2]
     deposit_log = escrow.events.Deposited.createFilter(fromBlock='latest')
     lock_log = escrow.events.Locked.createFilter(fromBlock='latest')
     activity_log = escrow.events.ActivityConfirmed.createFilter(fromBlock='latest')
@@ -68,7 +68,7 @@ def test_staking(testerchain, token, escrow_contract):
     # Check that nothing is locked
     assert 0 == escrow.functions.getLockedTokens(ursula1).call()
     assert 0 == escrow.functions.getLockedTokens(ursula2).call()
-    assert 0 == escrow.functions.getLockedTokens(testerchain.w3.eth.accounts[3]).call()
+    assert 0 == escrow.functions.getLockedTokens(testerchain.client.accounts[3]).call()
 
     # Ursula can't deposit tokens before Escrow initialization
     with pytest.raises((TransactionFailed, ValueError)):
@@ -457,8 +457,8 @@ def test_staking(testerchain, token, escrow_contract):
 @pytest.mark.slow
 def test_max_sub_stakes(testerchain, token, escrow_contract):
     escrow = escrow_contract(10000)
-    creator = testerchain.w3.eth.accounts[0]
-    ursula = testerchain.w3.eth.accounts[1]
+    creator = testerchain.client.accounts[0]
+    ursula = testerchain.client.accounts[1]
 
     # Initialize Escrow contract
     tx = escrow.functions.initialize().transact({'from': creator})

--- a/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow_additional.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow_additional.py
@@ -18,6 +18,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
 from eth_tester.exceptions import TransactionFailed
+from eth_utils import keccak
 from web3.contract import Contract
 
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
@@ -31,11 +32,11 @@ secret2 = (654321).to_bytes(32, byteorder='big')
 
 @pytest.mark.slow
 def test_upgrading(testerchain, token):
-    creator = testerchain.w3.eth.accounts[0]
-    staker = testerchain.w3.eth.accounts[1]
+    creator = testerchain.client.accounts[0]
+    staker = testerchain.client.accounts[1]
 
-    secret_hash = testerchain.w3.keccak(secret)
-    secret2_hash = testerchain.w3.keccak(secret2)
+    secret_hash = keccak(secret)
+    secret2_hash = keccak(secret2)
 
     # Deploy contract
     contract_library_v1, _ = testerchain.deploy_contract(
@@ -67,7 +68,7 @@ def test_upgrading(testerchain, token):
         _valueToCheck=2
     )
 
-    contract = testerchain.w3.eth.contract(
+    contract = testerchain.client.get_contract(
         abi=contract_library_v2.abi,
         address=dispatcher.address,
         ContractFactoryClass=Contract)
@@ -182,9 +183,9 @@ def test_upgrading(testerchain, token):
 @pytest.mark.slow
 def test_re_stake(testerchain, token, escrow_contract):
     escrow = escrow_contract(10000)
-    creator = testerchain.w3.eth.accounts[0]
-    ursula = testerchain.w3.eth.accounts[1]
-    ursula2 = testerchain.w3.eth.accounts[2]
+    creator = testerchain.client.accounts[0]
+    ursula = testerchain.client.accounts[1]
+    ursula2 = testerchain.client.accounts[2]
 
     re_stake_log = escrow.events.ReStakeSet.createFilter(fromBlock='latest')
     re_stake_lock_log = escrow.events.ReStakeLocked.createFilter(fromBlock='latest')
@@ -447,7 +448,7 @@ def test_re_stake(testerchain, token, escrow_contract):
 def test_worker(testerchain, token, escrow_contract):
     escrow = escrow_contract(10000)
     creator, ursula1, ursula2, ursula3, worker1, worker2, worker3, *everyone_else = \
-        testerchain.w3.eth.accounts
+        testerchain.client.accounts
 
     worker_log = escrow.events.WorkerSet.createFilter(fromBlock='latest')
 

--- a/tests/blockchain/eth/contracts/main/staking_escrow/test_tracking.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/test_tracking.py
@@ -25,7 +25,7 @@ from web3.contract import Contract
 def test_sampling(testerchain, token, escrow_contract):
     escrow = escrow_contract(5 * 10 ** 8)
     NULL_ADDR = '0x' + '0' * 40
-    creator = testerchain.w3.eth.accounts[0]
+    creator = testerchain.client.accounts[0]
 
     # Give Escrow tokens for reward and initialize contract
     tx = token.functions.transfer(escrow.address, 10 ** 9).transact({'from': creator})
@@ -143,11 +143,11 @@ def test_sampling(testerchain, token, escrow_contract):
 def test_pre_deposit(testerchain, token, escrow_contract):
     escrow = escrow_contract(1500)
     policy_manager_interface = testerchain.get_contract_factory('PolicyManagerForStakingEscrowMock')
-    policy_manager = testerchain.w3.eth.contract(
+    policy_manager = testerchain.client.get_contract(
         abi=policy_manager_interface.abi,
         address=escrow.functions.policyManager().call(),
         ContractFactoryClass=Contract)
-    creator = testerchain.w3.eth.accounts[0]
+    creator = testerchain.client.accounts[0]
 
     deposit_log = escrow.events.Deposited.createFilter(fromBlock='latest')
 
@@ -160,7 +160,7 @@ def test_pre_deposit(testerchain, token, escrow_contract):
     testerchain.wait_for_receipt(tx)
 
     # Deposit tokens for 1 staker
-    owner = testerchain.w3.eth.accounts[1]
+    owner = testerchain.client.accounts[1]
     tx = escrow.functions.preDeposit([owner], [1000], [10]).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     assert 1000 == token.functions.balanceOf(escrow.address).call()
@@ -177,26 +177,26 @@ def test_pre_deposit(testerchain, token, escrow_contract):
 
     # Can't pre-deposit tokens again for the same staker twice
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.preDeposit([testerchain.w3.eth.accounts[1]], [1000], [10])\
+        tx = escrow.functions.preDeposit([testerchain.client.accounts[1]], [1000], [10])\
             .transact({'from': creator})
         testerchain.wait_for_receipt(tx)
 
     # Can't pre-deposit tokens with too low or too high value
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.preDeposit([testerchain.w3.eth.accounts[2]], [1], [10])\
+        tx = escrow.functions.preDeposit([testerchain.client.accounts[2]], [1], [10])\
             .transact({'from': creator})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.preDeposit([testerchain.w3.eth.accounts[2]], [1501], [10])\
+        tx = escrow.functions.preDeposit([testerchain.client.accounts[2]], [1501], [10])\
             .transact({'from': creator})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.preDeposit([testerchain.w3.eth.accounts[2]], [500], [1])\
+        tx = escrow.functions.preDeposit([testerchain.client.accounts[2]], [500], [1])\
             .transact({'from': creator})
         testerchain.wait_for_receipt(tx)
 
     # Deposit tokens for multiple stakers
-    stakers = testerchain.w3.eth.accounts[2:7]
+    stakers = testerchain.client.accounts[2:7]
     tx = escrow.functions.preDeposit(
         stakers, [100, 200, 300, 400, 500], [50, 100, 150, 200, 250]).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
@@ -216,7 +216,7 @@ def test_pre_deposit(testerchain, token, escrow_contract):
     events = deposit_log.get_all_entries()
     assert 6 == len(events)
     event_args = events[0]['args']
-    assert testerchain.w3.eth.accounts[1] == event_args['staker']
+    assert testerchain.client.accounts[1] == event_args['staker']
     assert 1000 == event_args['value']
     assert 10 == event_args['periods']
     event_args = events[1]['args']

--- a/tests/blockchain/eth/contracts/main/token/test_token.py
+++ b/tests/blockchain/eth/contracts/main/token/test_token.py
@@ -28,11 +28,11 @@ def test_create_token(testerchain, token_economics):
     but some of the tests are converted from javascript to python
     """
 
-    creator = testerchain.w3.eth.accounts[0]
-    account1 = testerchain.w3.eth.accounts[1]
-    account2 = testerchain.w3.eth.accounts[2]
+    creator = testerchain.client.accounts[0]
+    account1 = testerchain.client.accounts[1]
+    account2 = testerchain.client.accounts[2]
 
-    assert creator == testerchain.w3.eth.coinbase
+    assert creator == testerchain.client.coinbase
 
     # Create an ERC20 token
     token, txhash = testerchain.deploy_contract('NuCypherToken', token_economics.erc20_total_supply)
@@ -49,7 +49,7 @@ def test_create_token(testerchain, token_economics):
 
     # Cannot send ETH to the contract because there is no payable function
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = testerchain.w3.eth.sendTransaction({'from': testerchain.w3.eth.coinbase,
+        tx = testerchain.client.sendTransaction({'from': testerchain.client.coinbase,
                                                            'to': token.address,
                                                            'value': 100,
                                                            'gasPrice': 0})
@@ -71,9 +71,9 @@ def test_create_token(testerchain, token_economics):
 
 @pytest.mark.slow()
 def test_approve_and_call(testerchain, token_economics):
-    creator = testerchain.w3.eth.accounts[0]
-    account1 = testerchain.w3.eth.accounts[1]
-    account2 = testerchain.w3.eth.accounts[2]
+    creator = testerchain.client.accounts[0]
+    account1 = testerchain.client.accounts[1]
+    account2 = testerchain.client.accounts[2]
 
     token, _ = testerchain.deploy_contract('NuCypherToken', token_economics.erc20_total_supply)
     mock, _ = testerchain.deploy_contract('ReceiveApprovalMethodMock')

--- a/tests/blockchain/eth/contracts/main/user_escrow/test_user_escrow.py
+++ b/tests/blockchain/eth/contracts/main/user_escrow/test_user_escrow.py
@@ -22,8 +22,8 @@ from eth_tester.exceptions import TransactionFailed
 
 @pytest.mark.slow
 def test_escrow(testerchain, token, user_escrow):
-    creator = testerchain.w3.eth.accounts[0]
-    user = testerchain.w3.eth.accounts[1]
+    creator = testerchain.client.accounts[0]
+    user = testerchain.client.accounts[1]
     deposits = user_escrow.events.TokensDeposited.createFilter(fromBlock='latest')
 
     # Deposit some tokens to the user escrow and lock them
@@ -108,8 +108,8 @@ def test_staker(testerchain, token, escrow, user_escrow, user_escrow_proxy, prox
     """
     Test staker functions in the user escrow
     """
-    creator = testerchain.w3.eth.accounts[0]
-    user = testerchain.w3.eth.accounts[1]
+    creator = testerchain.client.accounts[0]
+    user = testerchain.client.accounts[1]
 
     deposits = user_escrow.events.TokensDeposited.createFilter(fromBlock='latest')
 
@@ -296,9 +296,9 @@ def test_policy(testerchain, policy_manager, user_escrow, user_escrow_proxy):
     """
     Test policy manager functions in the user escrow
     """
-    creator = testerchain.w3.eth.accounts[0]
-    user = testerchain.w3.eth.accounts[1]
-    user_balance = testerchain.w3.eth.getBalance(user)
+    creator = testerchain.client.accounts[0]
+    user = testerchain.client.accounts[1]
+    user_balance = testerchain.client.get_balance(user)
 
     # Nothing to withdraw
     with pytest.raises((TransactionFailed, ValueError)):
@@ -307,12 +307,12 @@ def test_policy(testerchain, policy_manager, user_escrow, user_escrow_proxy):
     with pytest.raises((TransactionFailed, ValueError)):
         tx = user_escrow.functions.withdrawETH().transact({'from': user, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
-    assert user_balance == testerchain.w3.eth.getBalance(user)
-    assert 0 == testerchain.w3.eth.getBalance(user_escrow.address)
+    assert user_balance == testerchain.client.get_balance(user)
+    assert 0 == testerchain.client.get_balance(user_escrow.address)
 
     # Send ETH to the policy manager as a reward for the user
-    tx = testerchain.w3.eth.sendTransaction(
-        {'from': testerchain.w3.eth.coinbase, 'to': policy_manager.address, 'value': 10000})
+    tx = testerchain.client.sendTransaction(
+        {'from': testerchain.client.coinbase, 'to': policy_manager.address, 'value': 10000})
     testerchain.wait_for_receipt(tx)
 
     staker_reward = user_escrow_proxy.events.PolicyRewardWithdrawn.createFilter(fromBlock='latest')
@@ -329,9 +329,9 @@ def test_policy(testerchain, policy_manager, user_escrow, user_escrow_proxy):
     # User withdraws reward
     tx = user_escrow_proxy.functions.withdrawPolicyReward().transact({'from': user, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert user_balance + 10000 == testerchain.w3.eth.getBalance(user)
-    assert 0 == testerchain.w3.eth.getBalance(policy_manager.address)
-    assert 0 == testerchain.w3.eth.getBalance(user_escrow.address)
+    assert user_balance + 10000 == testerchain.client.get_balance(user)
+    assert 0 == testerchain.client.get_balance(policy_manager.address)
+    assert 0 == testerchain.client.get_balance(user_escrow.address)
 
     events = staker_reward.get_all_entries()
     assert 1 == len(events)

--- a/tests/blockchain/eth/entities/actors/test_policy_author.py
+++ b/tests/blockchain/eth/entities/actors/test_policy_author.py
@@ -23,13 +23,13 @@ from nucypher.utilities.sandbox.constants import DEVELOPMENT_ETH_AIRDROP_AMOUNT
 @pytest.mark.slow()
 @pytest.fixture(scope='module')
 def author(testerchain, agency):
-    _origin, ursula, alice, *everybody_else = testerchain.w3.eth.accounts
+    _origin, ursula, alice, *everybody_else = testerchain.client.accounts
     author = PolicyAuthor(checksum_address=alice, blockchain=testerchain)
     return author
 
 
 @pytest.mark.slow()
 def test_create_policy_author(testerchain, agency):
-    _origin, ursula, alice, *everybody_else = testerchain.w3.eth.accounts
+    _origin, ursula, alice, *everybody_else = testerchain.client.accounts
     policy_author = PolicyAuthor(checksum_address=alice, blockchain=testerchain)
     assert policy_author.checksum_address == alice

--- a/tests/blockchain/eth/entities/actors/test_staker.py
+++ b/tests/blockchain/eth/entities/actors/test_staker.py
@@ -28,7 +28,7 @@ from nucypher.utilities.sandbox.ursula import make_decentralized_ursulas
 @pytest.fixture(scope='module')
 def staker(testerchain, agency):
     token_agent, staking_agent, policy_agent = agency
-    origin, *everybody_else = testerchain.w3.eth.accounts
+    origin, *everybody_else = testerchain.client.accounts
     token_airdrop(token_agent=token_agent,
                   origin=testerchain.etherbase_account,
                   addresses=everybody_else,

--- a/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
@@ -130,7 +130,7 @@ def test_collect_policy_reward(testerchain, agency, policy_meta, token_economics
 
     staker = policy_meta.addresses[-1]
     ursula = staking_agent.get_worker_from_staker(staker)
-    old_eth_balance = token_agent.blockchain.w3.eth.getBalance(staker)
+    old_eth_balance = token_agent.blockchain.client.get_balance(staker)
 
     for _ in range(token_economics.minimum_locked_periods):
         _receipt = staking_agent.confirm_activity(worker_address=ursula)
@@ -139,5 +139,5 @@ def test_collect_policy_reward(testerchain, agency, policy_meta, token_economics
     receipt = agent.collect_policy_reward(collector_address=staker, staker_address=staker)
     assert receipt['status'] == 1, "Transaction Rejected"
     assert receipt['logs'][0]['address'] == agent.contract_address
-    new_eth_balance = token_agent.blockchain.w3.eth.getBalance(staker)
+    new_eth_balance = token_agent.blockchain.client.get_balance(staker)
     assert new_eth_balance > old_eth_balance

--- a/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
@@ -167,7 +167,7 @@ def test_divide_stake(agency, token_economics):
     token_agent, staking_agent, policy_agent = agency
     agent = staking_agent
     testerchain = agent.blockchain
-    origin, someone, *everybody_else = testerchain.w3.eth.accounts
+    origin, someone, *everybody_else = testerchain.client.accounts
 
     stakes = list(agent.get_all_stakes(staker_address=someone))
     assert len(stakes) == 1

--- a/tests/blockchain/eth/entities/agents/test_token_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_token_agent.py
@@ -23,7 +23,7 @@ from nucypher.blockchain.eth.deployers import NucypherTokenDeployer, DispatcherD
 
 @pytest.fixture(scope='module')
 def agent(testerchain):
-    origin, *everybody_else = testerchain.w3.eth.accounts
+    origin, *everybody_else = testerchain.client.accounts
     token_deployer = NucypherTokenDeployer(blockchain=testerchain, deployer_address=origin)
 
     token_deployer.deploy()
@@ -41,9 +41,9 @@ def test_token_properties(agent):
 
     # Cannot transfer any ETH to token contract
     with pytest.raises((TransactionFailed, ValueError)):
-        origin = testerchain.w3.eth.coinbase
+        origin = testerchain.client.coinbase
         payload = {'from': origin, 'to': agent.contract_address, 'value': 1}
-        tx = testerchain.w3.eth.sendTransaction(payload)
+        tx = testerchain.client.sendTransaction(payload)
         testerchain.wait_for_receipt(tx)
 
     assert len(agent.contract_address) == 42
@@ -54,7 +54,7 @@ def test_token_properties(agent):
 
 def test_get_balance(agent, token_economics):
     testerchain = agent.blockchain
-    deployer, someone, *everybody_else = testerchain.w3.eth.accounts
+    deployer, someone, *everybody_else = testerchain.client.accounts
     balance = agent.get_balance(address=someone)
     assert balance == 0
     balance = agent.get_balance(address=deployer)
@@ -63,7 +63,7 @@ def test_get_balance(agent, token_economics):
 
 def test_approve_transfer(agent, token_economics):
     testerchain = agent.blockchain
-    deployer, someone, *everybody_else = testerchain.w3.eth.accounts
+    deployer, someone, *everybody_else = testerchain.client.accounts
 
     # Approve
     receipt = agent.approve_transfer(amount=token_economics.minimum_allowed_locked,
@@ -76,7 +76,7 @@ def test_approve_transfer(agent, token_economics):
 
 def test_transfer(agent, token_economics):
     testerchain = agent.blockchain
-    origin, someone, *everybody_else = testerchain.w3.eth.accounts
+    origin, someone, *everybody_else = testerchain.client.accounts
 
     old_balance = agent.get_balance(someone)
     receipt = agent.transfer(amount=token_economics.minimum_allowed_locked,

--- a/tests/blockchain/eth/entities/deployers/test_interdeployer_integration.py
+++ b/tests/blockchain/eth/entities/deployers/test_interdeployer_integration.py
@@ -17,6 +17,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import os
 
 import pytest
+from eth_utils import keccak
 from constant_sorrow import constants
 
 from nucypher.blockchain.eth.agents import NucypherTokenAgent, StakingEscrowAgent, Agency
@@ -29,7 +30,7 @@ from nucypher.blockchain.eth.deployers import (NucypherTokenDeployer,
 @pytest.mark.slow()
 def test_deploy_ethereum_contracts(testerchain):
 
-    origin, *everybody_else = testerchain.w3.eth.accounts
+    origin, *everybody_else = testerchain.client.accounts
 
     #
     # Nucypher Token
@@ -66,7 +67,7 @@ def test_deploy_ethereum_contracts(testerchain):
         assert staking_escrow_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not staking_escrow_deployer.is_deployed
 
-    staking_escrow_deployer.deploy(secret_hash=testerchain.w3.keccak(stakers_escrow_secret))
+    staking_escrow_deployer.deploy(secret_hash=keccak(stakers_escrow_secret))
     assert staking_escrow_deployer.is_deployed
     assert len(staking_escrow_deployer.contract_address) == 42
 
@@ -93,7 +94,7 @@ def test_deploy_ethereum_contracts(testerchain):
         assert policy_manager_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not policy_manager_deployer.is_deployed
 
-    policy_manager_deployer.deploy(secret_hash=testerchain.w3.keccak(policy_manager_secret))
+    policy_manager_deployer.deploy(secret_hash=keccak(policy_manager_secret))
     assert policy_manager_deployer.is_deployed
     assert len(policy_manager_deployer.contract_address) == 42
 

--- a/tests/blockchain/eth/entities/deployers/test_policy_manager_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_policy_manager_deployer.py
@@ -17,6 +17,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 
 import os
+from eth_utils import keccak
 
 from nucypher.blockchain.eth.agents import PolicyAgent
 from nucypher.blockchain.eth.deployers import (
@@ -28,7 +29,7 @@ from nucypher.blockchain.eth.deployers import (
 
 
 def test_policy_manager_deployer(testerchain):
-    origin, *everybody_else = testerchain.w3.eth.accounts
+    origin, *everybody_else = testerchain.client.accounts
 
     token_deployer = NucypherTokenDeployer(blockchain=testerchain, deployer_address=origin)
 
@@ -39,14 +40,14 @@ def test_policy_manager_deployer(testerchain):
     stakers_escrow_secret = os.urandom(DispatcherDeployer.DISPATCHER_SECRET_LENGTH)
     staking_escrow_deployer = StakingEscrowDeployer(deployer_address=origin, blockchain=testerchain)
 
-    staking_escrow_deployer.deploy(secret_hash=testerchain.w3.keccak(stakers_escrow_secret))
+    staking_escrow_deployer.deploy(secret_hash=keccak(stakers_escrow_secret))
 
     staking_agent = staking_escrow_deployer.make_agent()  # 2 Staker Escrow
 
     policy_manager_secret = os.urandom(DispatcherDeployer.DISPATCHER_SECRET_LENGTH)
     deployer = PolicyManagerDeployer(deployer_address=origin, blockchain=testerchain)
 
-    deployment_txhashes = deployer.deploy(secret_hash=testerchain.w3.keccak(policy_manager_secret))
+    deployment_txhashes = deployer.deploy(secret_hash=keccak(policy_manager_secret))
     assert len(deployment_txhashes) == 3
 
     for title, txhash in deployment_txhashes.items():

--- a/tests/blockchain/eth/entities/deployers/test_staking_escrow_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_staking_escrow_deployer.py
@@ -21,7 +21,7 @@ from nucypher.blockchain.eth.deployers import NucypherTokenDeployer, StakingEscr
 
 
 def test_token_deployer_and_agent(testerchain):
-    origin, *everybody_else = testerchain.w3.eth.accounts
+    origin, *everybody_else = testerchain.client.accounts
 
     # The big day...
     token_deployer = NucypherTokenDeployer(blockchain=testerchain, deployer_address=origin)

--- a/tests/blockchain/eth/interfaces/test_chains.py
+++ b/tests/blockchain/eth/interfaces/test_chains.py
@@ -51,17 +51,17 @@ def test_testerchain_creation(testerchain, another_testerchain):
         assert chain.w3.eth.blockNumber > 0
 
         # Check that we have enough test accounts
-        assert len(chain.w3.eth.accounts) >= NUMBER_OF_ETH_TEST_ACCOUNTS
+        assert len(chain.client.accounts) >= NUMBER_OF_ETH_TEST_ACCOUNTS
 
         # Check that distinguished accounts are assigned
         etherbase = chain.etherbase_account
-        assert etherbase == chain.w3.eth.accounts[0]
+        assert etherbase == chain.client.accounts[0]
 
         alice = chain.alice_account
-        assert alice == chain.w3.eth.accounts[1]
+        assert alice == chain.client.accounts[1]
 
         bob = chain.bob_account
-        assert bob == chain.w3.eth.accounts[2]
+        assert bob == chain.client.accounts[2]
 
         stakers = [chain.staker_account(i) for i in range(NUMBER_OF_STAKERS_IN_BLOCKCHAIN_TESTS)]
         assert stakers == chain.stakers_accounts
@@ -73,14 +73,14 @@ def test_testerchain_creation(testerchain, another_testerchain):
         assert set([etherbase, alice, bob] + ursulas + stakers).isdisjoint(set(chain.unassigned_accounts))
 
         # Check that accounts are funded
-        for account in chain.w3.eth.accounts:
-            assert chain.w3.eth.getBalance(account) >= DEVELOPMENT_ETH_AIRDROP_AMOUNT
+        for account in chain.client.accounts:
+            assert chain.client.get_balance(account) >= DEVELOPMENT_ETH_AIRDROP_AMOUNT
 
         # Check that accounts can send transactions
-        for account in chain.w3.eth.accounts:
-            balance = chain.w3.eth.getBalance(account)
+        for account in chain.client.accounts:
+            balance = chain.client.get_balance(account)
             assert balance
 
             tx = {'to': etherbase, 'from': account, 'value': 100}
-            txhash = chain.w3.eth.sendTransaction(tx)
+            txhash = chain.client.sendTransaction(tx)
             _receipt = chain.wait_for_receipt(txhash)

--- a/tests/blockchain/eth/interfaces/test_solidity_compiler.py
+++ b/tests/blockchain/eth/interfaces/test_solidity_compiler.py
@@ -21,7 +21,7 @@ from nucypher.blockchain.eth.deployers import NucypherTokenDeployer
 
 def test_nucypher_contract_compiled(testerchain):
     # Ensure that solidity smart contacts are available, post-compile.
-    origin, *everybody_else = testerchain.w3.eth.accounts
+    origin, *everybody_else = testerchain.client.accounts
 
     token_contract_identifier = NucypherTokenDeployer(blockchain=testerchain, deployer_address=origin).contract_name
     assert token_contract_identifier in testerchain._BlockchainDeployerInterface__raw_contract_cache

--- a/tests/characters/test_crypto_characters_and_their_powers.py
+++ b/tests/characters/test_crypto_characters_and_their_powers.py
@@ -118,12 +118,12 @@ def test_anybody_can_verify():
 
 def test_character_blockchain_power(testerchain, agency):
     # TODO: Handle multiple providers
-    eth_address = testerchain.w3.eth.accounts[0]
+    eth_address = testerchain.client.accounts[0]
     canonical_address = eth_utils.to_canonical_address(eth_address)
     sig_privkey = testerchain.provider.ethereum_tester.backend._key_lookup[canonical_address]
 
     signer = Character(is_me=True, blockchain=testerchain, checksum_address=eth_address)
-    signer._crypto_power.consume_power_up(BlockchainPower(testerchain, eth_address))
+    signer._crypto_power.consume_power_up(BlockchainPower(testerchain.client, eth_address))
 
     # Due to testing backend, the account is already unlocked.
     power = signer._crypto_power.power_ups(BlockchainPower)
@@ -137,7 +137,7 @@ def test_character_blockchain_power(testerchain, agency):
     assert is_verified is True
 
     # Test a bad address/pubkey pair
-    is_verified = verify_eip_191(address=testerchain.w3.eth.accounts[1],
+    is_verified = verify_eip_191(address=testerchain.client.accounts[1],
                                  message=data_to_sign,
                                  signature=sig)
     assert is_verified is False

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -358,7 +358,7 @@ def test_nucypher_deploy_allocation_contracts(click_runner,
     assert result.exit_code == 0
 
     # ensure that a pre-allocation recipient has the allocated token quantity.
-    beneficiary = testerchain.w3.eth.accounts[-1]
+    beneficiary = testerchain.client.accounts[-1]
     allocation_registry = AllocationRegistry(registry_filepath=MOCK_ALLOCATION_REGISTRY_FILEPATH)
     user_escrow_agent = UserEscrowAgent(beneficiary=beneficiary, allocation_registry=allocation_registry)
     assert user_escrow_agent.unvested_tokens == token_economics.minimum_allowed_locked

--- a/tests/cli/test_felix.py
+++ b/tests/cli/test_felix.py
@@ -50,7 +50,7 @@ def test_run_felix(click_runner,
     # Felix creates a system configuration
     init_args = ('--debug',
                  'felix', 'init',
-                 '--checksum-address', testerchain.w3.eth.accounts[0],
+                 '--checksum-address', testerchain.client.accounts[0],
                  '--config-root', MOCK_CUSTOM_INSTALLATION_PATH_2,
                  '--network', TEMPORARY_DOMAIN,
                  '--no-registry',
@@ -102,7 +102,7 @@ def test_run_felix(click_runner,
         assert response.status_code == 200
 
         # Register a new recipient
-        response = test_client.post('/register', data={'address': felix.blockchain.w3.eth.accounts[-1]})
+        response = test_client.post('/register', data={'address': felix.blockchain.client.accounts[-1]})
         assert response.status_code == 200
 
         return
@@ -111,7 +111,7 @@ def test_run_felix(click_runner,
         clock.advance(amount=60)
 
     # Record starting ether balance
-    recipient = testerchain.w3.eth.accounts[-1]
+    recipient = testerchain.client.accounts[-1]
     staker = Staker(checksum_address=recipient,
                     blockchain=testerchain,
                     is_me=True)
@@ -125,7 +125,7 @@ def test_run_felix(click_runner,
     yield d
 
     def confirm_airdrop(_results):
-        recipient = testerchain.w3.eth.accounts[-1]
+        recipient = testerchain.client.accounts[-1]
         staker = Staker(checksum_address=recipient,
                         blockchain=testerchain,
                         is_me=True)

--- a/tests/cli/test_mixed_configurations.py
+++ b/tests/cli/test_mixed_configurations.py
@@ -33,7 +33,7 @@ def test_coexisting_configurations(click_runner,
                                    deploy_user_input):
 
     # Parse node addresses
-    deployer, alice, ursula, another_ursula, *all_yall = testerchain.w3.eth.accounts
+    deployer, alice, ursula, another_ursula, *all_yall = testerchain.client.accounts
 
     envvars = {'NUCYPHER_KEYRING_PASSWORD': INSECURE_DEVELOPMENT_PASSWORD,
 
@@ -197,7 +197,7 @@ def test_coexisting_configurations(click_runner,
 
 @pytest.mark.skip(reason="Skip until we have CLI for stakers (#1056)")
 def test_corrupted_configuration(click_runner, custom_filepath, testerchain, mock_primary_registry_filepath):
-    deployer, alice, ursula, another_ursula, *all_yall = testerchain.w3.eth.accounts
+    deployer, alice, ursula, another_ursula, *all_yall = testerchain.client.accounts
 
     init_args = ('ursula', 'init',
                  '--provider-uri', TEST_PROVIDER_URI,

--- a/tests/cli/ursula/test_blockchain_ursula.py
+++ b/tests/cli/ursula/test_blockchain_ursula.py
@@ -33,7 +33,7 @@ def configuration_file_location(custom_filepath):
 @pytest.fixture(scope="module")
 def charlie_blockchain_test_config(blockchain_ursulas, agency):
     token_agent, staking_agent, policy_agent = agency
-    etherbase, alice_address, bob_address, *everyone_else = token_agent.blockchain.w3.eth.accounts
+    etherbase, alice_address, bob_address, *everyone_else = token_agent.blockchain.client.accounts
 
     config = BobConfiguration(dev_mode=True,
                               provider_uri=TEST_PROVIDER_URI,
@@ -283,7 +283,7 @@ def test_collect_rewards_integration(click_runner,
     burner_wallet = blockchain.w3.eth.account.create(INSECURE_DEVELOPMENT_PASSWORD)
 
     # The rewards wallet is initially empty, because it is freshly created
-    assert blockchain.w3.eth.getBalance(burner_wallet.address) == 0
+    assert blockchain.client.get_balance(burner_wallet.address) == 0
 
     # Snag a random teacher from the fleet
     collection_args = ('--mock-networking',
@@ -299,7 +299,7 @@ def test_collect_rewards_integration(click_runner,
     assert result.exit_code == 0
 
     # Policy Reward
-    collected_policy_reward = blockchain.w3.eth.getBalance(burner_wallet.address)
+    collected_policy_reward = blockchain.client.get_balance(burner_wallet.address)
     expected_collection = policy_rate * 30
     assert collected_policy_reward == expected_collection
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -478,7 +478,7 @@ def policy_value(token_economics, policy_rate):
 def funded_blockchain(testerchain, agency, token_economics):
 
     # Who are ya'?
-    deployer_address, *everyone_else, staking_participant = testerchain.w3.eth.accounts
+    deployer_address, *everyone_else, staking_participant = testerchain.client.accounts
 
     # Free ETH!!!
     testerchain.ether_airdrop(amount=DEVELOPMENT_ETH_AIRDROP_AMOUNT)

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -174,7 +174,7 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     web3 = testerchain.w3
 
     # Accounts
-    origin, ursula1, ursula2, ursula3, alice1, *everyone_else = testerchain.w3.eth.accounts
+    origin, ursula1, ursula2, ursula3, alice1, *everyone_else = testerchain.client.accounts
 
     ursula_with_stamp = mock_ursula_with_stamp()
 


### PR DESCRIPTION
* gets rid of magic __getattr__
* removes most relevant possible client specific calls to w3.
* Only about 4 (pending finish running) tests failing and it is for other reasons than attribute errors and you probably fixed them already