### PR TITLE
Allow retrieval of old network events that are no longer present in current contracts

### DIFF
--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -672,7 +672,7 @@ class BlockchainInterface:
                              contract_version: str = None,
                              enrollment_version: Union[int, str] = None,
                              proxy_name: str = None,
-                             use_proxy_address: bool = True,
+                             use_proxy_address: bool = True
                              ) -> VersionedContract:
         """
         Instantiate a deployed contract from registry data,

--- a/nucypher/cli/commands/status.py
+++ b/nucypher/cli/commands/status.py
@@ -210,7 +210,7 @@ def events(general_config, registry_options, contract_name, from_block, to_block
                 contract_name=contract_name,
                 contract_version=contract_version,
                 proxy_name='Dispatcher',
-                use_proxy_address=True,
+                use_proxy_address=True
                )
             agent = EthereumContractAgent(contract=versioned_contract)
             agent.contract_name = contract_name


### PR DESCRIPTION
Old StakingEscrow events:

```bash
$ nucypher status events --contract-name StakingEscrow --event-name Minted --provider <PROVIDER> --event-filter staker=0xeE449FFE36139620B0eBAe041f32f1381b0C72d1 --from-block 0 --legacy  --registry-filepath ./nucypher/blockchain/eth/contract_registry/ibex/contract_registry.json

Reading Latest Chaindata...
Retrieving events from block 0 to latest

----- StakingEscrow v5.7.1 Events ------

Minted:
  - (EventRecord) staker: 0xeE449FFE36139620B0eBAe041f32f1381b0C72d1, period: 9365, value: 539988017441094385131, block_number: 8414166
  - (EventRecord) staker: 0xeE449FFE36139620B0eBAe041f32f1381b0C72d1, period: 9371, value: 440828578890440959187, block_number: 8492225
  - (EventRecord) staker: 0xeE449FFE36139620B0eBAe041f32f1381b0C72d1, period: 9431, value: 614905677055795193508, block_number: 9183477
```


Old Policy Manager events:
```bash
$ nucypher status events --contract-name PolicyManager --event-name PolicyCreated --provider <PROVIDER> --from-block 0 --legacy  --registry-filepath ./nucypher/blockchain/eth/contract_registry/ibex/contract_registry.json

Reading Latest Chaindata...
Retrieving events from block 0 to latest

----- PolicyManager v6.2.1 Events ------

PolicyCreated:
  - (EventRecord) policyId: b'\xb4\x16\xca\xca\xd0\xf1\r2g{\xef\xc16\xa8\x91\x94', sponsor: 0xB7b1B91Aa39bE326294f6D4cafE357bEb4B34Ac1, owner: 0xB7b1B91Aa39bE326294f6D4cafE357bEb4B34Ac1, feeRate: 10, startTimestamp: 1591748210, endTimestamp: 1592265600, numberOfNodes: 3, block_number: 6639516
  - (EventRecord) policyId: b'\x17\x0b\t\x81y\x95\xac]7r92W\xf1\xed\x05', sponsor: 0xB7b1B91Aa39bE326294f6D4cafE357bEb4B34Ac1, owner: 0xB7b1B91Aa39bE326294f6D4cafE357bEb4B34Ac1, feeRate: 100, startTimestamp: 1592270334, endTimestamp: 1594771200, numberOfNodes: 5, block_number: 6674324
  - (EventRecord) policyId: b'({\x89\xc5V\xcc\xf0"\x9d\xb4\xba\x0c\xcc\xc5w\xb4', sponsor: 0xB7b1B91Aa39bE326294f6D4cafE357bEb4B34Ac1, owner: 0xB7b1B91Aa39bE326294f6D4cafE357bEb4B34Ac1, feeRate: 100, startTimestamp: 1592271309, endTimestamp: 1594857600, numberOfNodes: 5, block_number: 6674389
  ...
  ```